### PR TITLE
Explicitly set `hostUsers: true` for kubernetes

### DIFF
--- a/flx-dev-plugin.yaml
+++ b/flx-dev-plugin.yaml
@@ -21,11 +21,13 @@ spec:
         app.kubernetes.io/app: flx-plugin
         app.kubernetes.io/component: flx-plugin
     spec:
+      hostUsers: true
       initContainers:
       - name: flx-driver
         image: ghcr.io/dune-daq/flx-init-driver-alma9:latest
         securityContext:
           privileged: true
+          runAsNonRoot: false
         volumeMounts:
           - name: devfs
             mountPath: /dev
@@ -36,6 +38,7 @@ spec:
       - name: flx-plugin
         image: ghcr.io/dune-daq/flx-device-plugin:latest
         securityContext:
+          runAsNonRoot: false
           allowPrivilegeEscalation: false
         volumeMounts:
         - name: devfs


### PR DESCRIPTION
The daemons require host privileges. Setting this explicitly both documents the incompatibility with user namespaces and ensures, if the default changes, the daemonset will continue to function as expected.
